### PR TITLE
Fix access to context.request when Serializer is nested

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,37 @@ the fields:
       ...
     ]
 
+And a query with the `omit` parameter excludes specified fields.
+
+``GET /identities/?omit=data``
+
+.. sourcecode:: json
+
+    [
+      {
+        "id": 1,
+        "url": "http://localhost:8000/api/identities/1/",
+        "type": 5
+      },
+      ...
+    ]
+
+You can use both `fields` and `omit` in the same request!
+
+``GET /identities/?omit=data,fields=data,id``
+
+.. sourcecode:: json
+
+    [
+      {
+        "id": 1
+      },
+      ...
+    ]
+
+
+Though why you would want to do something like that is beyond this author.
+
 It also works on single objects!
 
 ``GET /identities/1/?fields=id,data``

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -1,7 +1,6 @@
 """
 Mixin to dynamically select only a subset of fields per DRF resource.
 """
-
 import warnings
 
 
@@ -10,32 +9,34 @@ class DynamicFieldsMixin(object):
     A serializer mixin that takes an additional `fields` argument that controls
     which fields should be displayed.
     """
-    def __init__(self, *args, **kwargs):
-        super(DynamicFieldsMixin, self).__init__(*args, **kwargs)
 
-        # If the context is not set, return
-        if 'context' not in kwargs:
-            return
-
-        # If the request is not passed in, warn and return
-        if 'request' not in self.context:
+    @property
+    def fields(self):
+        fields = super(DynamicFieldsMixin, self).fields
+        try:
+            request = self.context['request']
+        except KeyError:
             warnings.warn('Context does not have access to request')
-            return
+            return fields
 
         # NOTE: drf test framework builds a request object where the query
         # parameters are found under the GET attribute.
-        if hasattr(self.context['request'], 'query_params'):
-            fields = self.context['request'].query_params.get('fields', None)
-        elif hasattr(self.context['request'], 'GET'):
-            fields = self.context['request'].GET.get('fields', None)
-        else:
+        params = getattr(
+            request, 'query_params', getattr(request, 'GET', None)
+        )
+        if not params:
             warnings.warn('Request object does not contain query paramters')
-            return
 
-        if fields:
-            fields = fields.split(',')
-            # Drop any fields that are not specified in the `fields` argument.
-            allowed = set(fields)
-            existing = set(self.fields.keys())
-            for field_name in existing - allowed:
-                self.fields.pop(field_name)
+        try:
+            filter_fields = params.get('fields', None).split(',')
+        except AttributeError:
+            return fields
+
+        # Drop any fields that are not specified in the `fields` argument.
+        allowed = set(filter(None, filter_fields))
+        existing = set(fields.keys())
+
+        for field in existing - allowed:
+            fields.pop(field)
+
+        return fields

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -42,7 +42,7 @@ class DynamicFieldsMixin(object):
         try:
             filter_fields = params.get('fields', None).split(',')
         except AttributeError:
-            filter_fields = []
+            filter_fields = None
 
         try:
             omit_fields = params.get('omit', None).split(',')
@@ -50,14 +50,17 @@ class DynamicFieldsMixin(object):
             omit_fields = []
 
         # Drop any fields that are not specified in the `fields` argument.
-        allowed = set(filter(None, filter_fields))
         existing = set(fields.keys())
+        if filter_fields is None:
+            # no fields param given, don't filter.
+            allowed = existing
+        else:
+            allowed = set(filter(None, filter_fields))
 
         # omit fields in the `omit` argument.
         omitted = set(filter(None, omit_fields))
 
-
-        for field in reversed(fields):
+        for field in existing:
 
             if field not in allowed:
                 fields.pop(field)

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -14,7 +14,7 @@ class DynamicFieldsMixin(object):
         super(DynamicFieldsMixin, self).__init__(*args, **kwargs)
 
         # If the context is not set, return
-        if not self.context:
+        if 'context' not in kwargs:
             return
 
         # If the request is not passed in, warn and return

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -30,13 +30,27 @@ class DynamicFieldsMixin(object):
         try:
             filter_fields = params.get('fields', None).split(',')
         except AttributeError:
-            return fields
+            filter_fields = []
+
+        try:
+            omit_fields = params.get('omit', None).split(',')
+        except AttributeError:
+            omit_fields = []
 
         # Drop any fields that are not specified in the `fields` argument.
         allowed = set(filter(None, filter_fields))
         existing = set(fields.keys())
 
-        for field in existing - allowed:
-            fields.pop(field)
+        # omit fields in the `omit` argument.
+        omitted = set(filter(None, omit_fields))
+
+
+        for field in reversed(fields):
+
+            if field not in allowed:
+                fields.pop(field)
+
+            if field in omitted:
+                fields.pop(field)
 
         return fields

--- a/drf_dynamic_fields/apps.py
+++ b/drf_dynamic_fields/apps.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8
+from django.apps import AppConfig
+
+
+class DrfDynamicFieldsConfig(AppConfig):
+    name = 'drf_dynamic_fields'

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, absolute_import
+
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+import os
+import sys
+
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+
+def run_tests(*test_args):
+    if not test_args:
+        test_args = ['tests']
+
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(test_args)
+    sys.exit(bool(failures))
+
+
+if __name__ == '__main__':
+    run_tests(*sys.argv[1:])

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class Teacher(models.Model):
+    pass
+
+
+class School(models.Model):
+    teachers = models.ManyToManyField(Teacher)

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -14,7 +14,14 @@ class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         fields = ('id', 'request_info')
 
     def get_request_info(self, teacher):
-        return str(self.context['request'])
+        """
+        a meaningless method that attempts
+        to access the request object.
+        """
+        request = self.context['request']
+        return request.build_absolute_uri(
+            '/api/v1/teacher/{}'.format(teacher.pk)
+        )
 
 
 class SchoolSerializer(serializers.ModelSerializer):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,0 +1,26 @@
+from django.db import models
+
+from rest_framework import serializers
+
+from drf_dynamic_fields import DynamicFieldsMixin
+
+from .models import Teacher, School
+
+
+class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    request_info = serializers.SerializerMethodField()
+    class Meta:
+        model = Teacher
+        fields = ('id', 'request_info')
+
+    def get_request_info(self, teacher):
+        return str(self.context['request'])
+
+
+class SchoolSerializer(serializers.ModelSerializer):
+
+    teachers = TeacherSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = School
+        fields = ('id', 'teachers')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+import django
+
+DEBUG = True
+USE_TZ = True
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = "**************************************************"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+ROOT_URLCONF = "tests.urls"
+
+INSTALLED_APPS = [
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sites",
+    "drf_dynamic_fields",
+    "tests"
+]
+
+SITE_ID = 1
+
+if django.VERSION >= (1, 10):
+    MIDDLEWARE = ()
+else:
+    MIDDLEWARE_CLASSES = ()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_drf-dynamic-fields
+------------
+
+Tests for `drf-dynamic-fields` mixins
+"""
+
+from django.test import TestCase, RequestFactory
+from drf_dynamic_fields import DynamicFieldsMixin
+
+from .serializers import SchoolSerializer
+from .models import Teacher, School
+
+
+class TestDynamicFieldsMixin(TestCase):
+
+    def test_as_nested_serializer(self):
+
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/')
+
+        school = School.objects.create()
+        school.teachers.add(
+            Teacher.objects.create(),
+            Teacher.objects.create()
+        )
+
+        serializer = SchoolSerializer(school, context={'request': request})
+
+        self.assertEqual(
+            serializer.data, {
+            }
+        )
+
+
+

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -12,11 +12,44 @@ from collections import OrderedDict
 from django.test import TestCase, RequestFactory
 from drf_dynamic_fields import DynamicFieldsMixin
 
-from .serializers import SchoolSerializer
+from .serializers import SchoolSerializer, TeacherSerializer
 from .models import Teacher, School
 
 
 class TestDynamicFieldsMixin(TestCase):
+
+    def test_removes_fields(self):
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?fields=id')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id',))
+        )
+
+    def test_fields_left_alone(self):
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id', 'request_info'))
+        )
+
+    def test_ordinary_serializer(self):
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?fields=id')
+        teacher = Teacher.objects.create()
+
+        serializer = TeacherSerializer(teacher, context={'request': request})
+
+        self.assertEqual(
+            serializer.data, {
+                'id': teacher.id
+            }
+        )
 
     def test_as_nested_serializer(self):
 
@@ -49,6 +82,3 @@ class TestDynamicFieldsMixin(TestCase):
                 'id': school.id
             }
         )
-
-
-

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -75,6 +75,58 @@ class TestDynamicFieldsMixin(TestCase):
             }
         )
 
+    def test_omit(self):
+        """
+        Check a basic usage of omit.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?omit=request_info')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id',))
+        )
+
+    def test_omit_and_fields_used(self):
+        """
+        Can they be used together.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?fields=id,request_info&omit=request_info')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id',))
+        )
+
+    def test_omit_everything(self):
+        """
+        Can remove it all tediously.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?omit=id,request_info')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set()
+        )
+
+    def test_omit_nothing(self):
+        """
+        Blank omit doesn't affect anything.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?omit')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id', 'request_info'))
+        )
+
     def test_as_nested_serializer(self):
         """
         Nested serializers are not filtered.

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+from django.conf.urls import url, include
+
+urlpatterns = []


### PR DESCRIPTION
`DynamicFieldsMixin` causes nested serializer to behave improperly if they require access to `context`.

When a serializer using `DynamicFieldsMixin` is nested, the `self.context` cached_property is accessed during `__init__`, and `__init__` is called at django startup time, not request time.

Subsequent calls will return the value of `self.context` that existed during django startup, and won't have the `context` correctly set from its parent.

This fix will mean that nested serializers don't respond to the `fields` query param.  They never did anyway, so this shouldn't affect anyone's production code.

I believe it is correct behaviour to exclude nested serializers from responding to `fields`. It would be quite unexpected if both the parent and children serializers all dynamically altered their fields.

This pull request includes some tests that you can use regardless of accepting the fix. The fix itself is only 1 line/commit, and is easy to revert and accept the rest if you decide you wanted to address it a different way.