### PR TITLE
Override fields not init

### DIFF
--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -1,7 +1,6 @@
 """
 Mixin to dynamically select only a subset of fields per DRF resource.
 """
-
 import warnings
 
 
@@ -10,32 +9,34 @@ class DynamicFieldsMixin(object):
     A serializer mixin that takes an additional `fields` argument that controls
     which fields should be displayed.
     """
-    def __init__(self, *args, **kwargs):
-        super(DynamicFieldsMixin, self).__init__(*args, **kwargs)
 
-        # If the context is not set, return
-        if 'context' not in kwargs:
-            return
-
-        # If the request is not passed in, warn and return
-        if 'request' not in self.context:
+    @property
+    def fields(self):
+        fields = super(DynamicFieldsMixin, self).fields
+        try:
+            request = self.context['request']
+        except KeyError:
             warnings.warn('Context does not have access to request')
-            return
+            return fields
 
         # NOTE: drf test framework builds a request object where the query
         # parameters are found under the GET attribute.
-        if hasattr(self.context['request'], 'query_params'):
-            fields = self.context['request'].query_params.get('fields', None)
-        elif hasattr(self.context['request'], 'GET'):
-            fields = self.context['request'].GET.get('fields', None)
-        else:
+        params = getattr(
+            request, 'query_params', getattr(request, 'GET', None)
+        )
+        if not params:
             warnings.warn('Request object does not contain query paramters')
-            return
 
-        if fields:
-            fields = fields.split(',')
-            # Drop any fields that are not specified in the `fields` argument.
-            allowed = set(fields)
-            existing = set(self.fields.keys())
-            for field_name in existing - allowed:
-                self.fields.pop(field_name)
+        try:
+            filter_fields = params.get('fields', None).split(',')
+        except AttributeError:
+            return fields
+
+        # Drop any fields that are not specified in the `fields` argument.
+        allowed = set(filter(None, filter_fields))
+        existing = set(fields.keys())
+
+        for field in existing - allowed:
+            fields.pop(field)
+
+        return fields

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -14,7 +14,7 @@ class DynamicFieldsMixin(object):
         super(DynamicFieldsMixin, self).__init__(*args, **kwargs)
 
         # If the context is not set, return
-        if not self.context:
+        if 'context' not in kwargs:
             return
 
         # If the request is not passed in, warn and return

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -29,7 +29,7 @@ class DynamicFieldsMixin(object):
         params = getattr(
             request, 'query_params', getattr(request, 'GET', None)
         )
-        if not params:
+        if params is None:
             warnings.warn('Request object does not contain query paramters')
 
         try:

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -13,6 +13,11 @@ class DynamicFieldsMixin(object):
     @property
     def fields(self):
         fields = super(DynamicFieldsMixin, self).fields
+
+        if not hasattr(self, '_context'):
+            # we are being called before a request cycle.
+            return fields
+
         try:
             request = self.context['request']
         except KeyError:

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -12,6 +12,13 @@ class DynamicFieldsMixin(object):
 
     @property
     def fields(self):
+        """
+        Filters the fields according to the `fields` query parameter.
+
+        a blank `fields` parameter (?fields) will remove all fields.
+        not passing `fields` will pass all fields
+        individual fields are comma separated (?fields=id,name,url,email)
+        """
         fields = super(DynamicFieldsMixin, self).fields
 
         if not hasattr(self, '_context'):

--- a/drf_dynamic_fields/apps.py
+++ b/drf_dynamic_fields/apps.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8
-from django.apps import AppConfig
-
-
-class DrfDynamicFieldsConfig(AppConfig):
-    name = 'drf_dynamic_fields'

--- a/drf_dynamic_fields/apps.py
+++ b/drf_dynamic_fields/apps.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8
+from django.apps import AppConfig
+
+
+class DrfDynamicFieldsConfig(AppConfig):
+    name = 'drf_dynamic_fields'

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, absolute_import
+
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+For running tests.
+"""
 from __future__ import unicode_literals, absolute_import
 
 import os

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+import os
+import sys
+
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+
+def run_tests(*test_args):
+    if not test_args:
+        test_args = ['tests']
+
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(test_args)
+    sys.exit(bool(failures))
+
+
+if __name__ == '__main__':
+    run_tests(*sys.argv[1:])

--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
+"""
+Run tests with python runtests.py
+
+Taken from the django cookiecutter project.
+"""
 from __future__ import unicode_literals, absolute_import
 
 import os
@@ -11,12 +16,15 @@ from django.test.utils import get_runner
 
 
 def run_tests(*test_args):
+    """
+    I am here to satisfy the code quality checker.
+    """
     if not test_args:
         test_args = ['tests']
 
     os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
     django.setup()
-    TestRunner = get_runner(settings)
+    TestRunner = get_runner(settings)  # noqa
     test_runner = TestRunner()
     failures = test_runner.run_tests(test_args)
     sys.exit(bool(failures))

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class Teacher(models.Model):
+    pass
+
+
+class School(models.Model):
+    teachers = models.ManyToManyField(Teacher)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,9 +1,13 @@
+"""
+Some models for the tests. We are modelling a school.
+"""
 from django.db import models
 
 
 class Teacher(models.Model):
-    pass
+    """No fields, no fun."""
 
 
 class School(models.Model):
+    """Schools just have teachers, no students."""
     teachers = models.ManyToManyField(Teacher)

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,5 +1,6 @@
-from django.db import models
-
+"""
+For the tests.
+"""
 from rest_framework import serializers
 
 from drf_dynamic_fields import DynamicFieldsMixin
@@ -8,7 +9,13 @@ from .models import Teacher, School
 
 
 class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    """
+    The request_info field is to highlight the issue accessing request during
+    a nested serializer.
+    """
+
     request_info = serializers.SerializerMethodField()
+
     class Meta:
         model = Teacher
         fields = ('id', 'request_info')
@@ -25,6 +32,10 @@ class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
 
 class SchoolSerializer(serializers.ModelSerializer):
+    """
+    Interesting enough serializer because the TeacherSerializer
+    will use ListSerializer due to the `many=True`
+    """
 
     teachers = TeacherSerializer(many=True, read_only=True)
 

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -14,7 +14,14 @@ class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         fields = ('id', 'request_info')
 
     def get_request_info(self, teacher):
-        return str(self.context['request'])
+        """
+        a meaningless method that attempts
+        to access the request object.
+        """
+        request = self.context['request']
+        return request.build_absolute_uri(
+            '/api/v1/teacher/{}'.format(teacher.pk)
+        )
 
 
 class SchoolSerializer(serializers.ModelSerializer):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,0 +1,26 @@
+from django.db import models
+
+from rest_framework import serializers
+
+from drf_dynamic_fields import DynamicFieldsMixin
+
+from .models import Teacher, School
+
+
+class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    request_info = serializers.SerializerMethodField()
+    class Meta:
+        model = Teacher
+        fields = ('id', 'request_info')
+
+    def get_request_info(self, teacher):
+        return str(self.context['request'])
+
+
+class SchoolSerializer(serializers.ModelSerializer):
+
+    teachers = TeacherSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = School
+        fields = ('id', 'teachers')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8
+"""
+Settings for test.
+"""
 from __future__ import unicode_literals, absolute_import
 
 import django

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+import django
+
+DEBUG = True
+USE_TZ = True
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = "**************************************************"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+ROOT_URLCONF = "tests.urls"
+
+INSTALLED_APPS = [
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sites",
+    "drf_dynamic_fields",
+    "tests"
+]
+
+SITE_ID = 1
+
+if django.VERSION >= (1, 10):
+    MIDDLEWARE = ()
+else:
+    MIDDLEWARE_CLASSES = ()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_drf-dynamic-fields
+------------
+
+Tests for `drf-dynamic-fields` mixins
+"""
+
+from django.test import TestCase, RequestFactory
+from drf_dynamic_fields import DynamicFieldsMixin
+
+from .serializers import SchoolSerializer
+from .models import Teacher, School
+
+
+class TestDynamicFieldsMixin(TestCase):
+
+    def test_as_nested_serializer(self):
+
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/')
+
+        school = School.objects.create()
+        school.teachers.add(
+            Teacher.objects.create(),
+            Teacher.objects.create()
+        )
+
+        serializer = SchoolSerializer(school, context={'request': request})
+
+        self.assertEqual(
+            serializer.data, {
+            }
+        )
+
+
+

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -12,11 +12,44 @@ from collections import OrderedDict
 from django.test import TestCase, RequestFactory
 from drf_dynamic_fields import DynamicFieldsMixin
 
-from .serializers import SchoolSerializer
+from .serializers import SchoolSerializer, TeacherSerializer
 from .models import Teacher, School
 
 
 class TestDynamicFieldsMixin(TestCase):
+
+    def test_removes_fields(self):
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?fields=id')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id',))
+        )
+
+    def test_fields_left_alone(self):
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id', 'request_info'))
+        )
+
+    def test_ordinary_serializer(self):
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?fields=id')
+        teacher = Teacher.objects.create()
+
+        serializer = TeacherSerializer(teacher, context={'request': request})
+
+        self.assertEqual(
+            serializer.data, {
+                'id': teacher.id
+            }
+        )
 
     def test_as_nested_serializer(self):
 
@@ -49,6 +82,3 @@ class TestDynamicFieldsMixin(TestCase):
                 'id': school.id
             }
         )
-
-
-

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -10,15 +10,20 @@ Tests for `drf-dynamic-fields` mixins
 from collections import OrderedDict
 
 from django.test import TestCase, RequestFactory
-from drf_dynamic_fields import DynamicFieldsMixin
 
 from .serializers import SchoolSerializer, TeacherSerializer
 from .models import Teacher, School
 
 
 class TestDynamicFieldsMixin(TestCase):
+    """
+    Test case for the DynamicFieldsMixin
+    """
 
     def test_removes_fields(self):
+        """
+        Does it actually remove fields?
+        """
         rf = RequestFactory()
         request = rf.get('/api/v1/schools/1/?fields=id')
         serializer = TeacherSerializer(context={'request': request})
@@ -29,6 +34,9 @@ class TestDynamicFieldsMixin(TestCase):
         )
 
     def test_fields_left_alone(self):
+        """
+        What if no fields param is passed? It should not touch the fields.
+        """
         rf = RequestFactory()
         request = rf.get('/api/v1/schools/1/')
         serializer = TeacherSerializer(context={'request': request})
@@ -38,7 +46,23 @@ class TestDynamicFieldsMixin(TestCase):
             set(('id', 'request_info'))
         )
 
+    def test_fields_all_gone(self):
+        """
+        If we pass a blank fields list, then no fields should return.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?fields')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set()
+        )
+
     def test_ordinary_serializer(self):
+        """
+        Check the full JSON output of the serializer.
+        """
         rf = RequestFactory()
         request = rf.get('/api/v1/schools/1/?fields=id')
         teacher = Teacher.objects.create()
@@ -52,6 +76,9 @@ class TestDynamicFieldsMixin(TestCase):
         )
 
     def test_as_nested_serializer(self):
+        """
+        Nested serializers are not filtered.
+        """
 
         rf = RequestFactory()
         request = rf.get('/api/v1/schools/1/')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+from django.conf.urls import url, include
+
+urlpatterns = []

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8
-from __future__ import unicode_literals, absolute_import
-
-from django.conf.urls import url, include
-
-urlpatterns = []
+"""
+Empty urls for test.
+"""
+urlpatterns = []  # noqa.


### PR DESCRIPTION
Not sure, but it might be nicer to move field related filtering into the `fields` property rather than editing directly during `__init__`.

