### PR TITLE
Add omit feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,37 @@ the fields:
       ...
     ]
 
+And a query with the `omit` parameter excludes specified fields.
+
+``GET /identities/?omit=data``
+
+.. sourcecode:: json
+
+    [
+      {
+        "id": 1,
+        "url": "http://localhost:8000/api/identities/1/",
+        "type": 5
+      },
+      ...
+    ]
+
+You can use both `fields` and `omit` in the same request!
+
+``GET /identities/?omit=data,fields=data,id``
+
+.. sourcecode:: json
+
+    [
+      {
+        "id": 1
+      },
+      ...
+    ]
+
+
+Though why you would want to do something like that is beyond this author.
+
 It also works on single objects!
 
 ``GET /identities/1/?fields=id,data``

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -42,13 +42,30 @@ class DynamicFieldsMixin(object):
         try:
             filter_fields = params.get('fields', None).split(',')
         except AttributeError:
-            return fields
+            filter_fields = None
+
+        try:
+            omit_fields = params.get('omit', None).split(',')
+        except AttributeError:
+            omit_fields = []
 
         # Drop any fields that are not specified in the `fields` argument.
-        allowed = set(filter(None, filter_fields))
         existing = set(fields.keys())
+        if filter_fields is None:
+            # no fields param given, don't filter.
+            allowed = existing
+        else:
+            allowed = set(filter(None, filter_fields))
 
-        for field in existing - allowed:
-            fields.pop(field)
+        # omit fields in the `omit` argument.
+        omitted = set(filter(None, omit_fields))
+
+        for field in existing:
+
+            if field not in allowed:
+                fields.pop(field, None)
+
+            if field in omitted:
+                fields.pop(field, None)
 
         return fields

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -75,6 +75,68 @@ class TestDynamicFieldsMixin(TestCase):
             }
         )
 
+    def test_omit(self):
+        """
+        Check a basic usage of omit.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?omit=request_info')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id',))
+        )
+
+    def test_omit_and_fields_used(self):
+        """
+        Can they be used together.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?fields=id,request_info&omit=request_info')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id',))
+        )
+
+    def test_omit_everything(self):
+        """
+        Can remove it all tediously.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?omit=id,request_info')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set()
+        )
+
+    def test_omit_nothing(self):
+        """
+        Blank omit doesn't affect anything.
+        """
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?omit')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id', 'request_info'))
+        )
+
+    def test_omit_non_existant_field(self):
+        rf = RequestFactory()
+        request = rf.get('/api/v1/schools/1/?omit=pretend')
+        serializer = TeacherSerializer(context={'request': request})
+
+        self.assertEqual(
+            set(serializer.fields.keys()),
+            set(('id', 'request_info'))
+        )
+
     def test_as_nested_serializer(self):
         """
         Nested serializers are not filtered.


### PR DESCRIPTION
Omit is used as the inverse of `fields`. You can either include or
exclude fields per request.

I find that `omit` is useful when wanting all fields except one
expensive to compute one, while `fields` is useful when cherry picking
a handful of fields from a larger serializer