### PR TITLE
Do not apply filter to nested serializers

### DIFF
--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -15,14 +15,22 @@ class DynamicFieldsMixin(object):
         """
         Filters the fields according to the `fields` query parameter.
 
-        a blank `fields` parameter (?fields) will remove all fields.
-        not passing `fields` will pass all fields
-        individual fields are comma separated (?fields=id,name,url,email)
+        A blank `fields` parameter (?fields) will remove all fields. Not
+        passing `fields` will pass all fields individual fields are comma
+        separated (?fields=id,name,url,email).
+
         """
         fields = super(DynamicFieldsMixin, self).fields
 
         if not hasattr(self, '_context'):
-            # we are being called before a request cycle.
+            # We are being called before a request cycle
+            return fields
+
+        # Only filter if this is the root serializer, or if the parent is the
+        # root serializer with many=True
+        is_root = self.root == self
+        parent_is_list_root = self.parent == self.root and getattr(self.parent, 'many', False)
+        if not (is_root or parent_is_list_root):
             return fields
 
         try:

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -31,7 +31,7 @@ class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         )
 
 
-class SchoolSerializer(serializers.ModelSerializer):
+class SchoolSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     """
     Interesting enough serializer because the TeacherSerializer
     will use ListSerializer due to the `many=True`

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -141,9 +141,8 @@ class TestDynamicFieldsMixin(TestCase):
         """
         Nested serializers are not filtered.
         """
-
         rf = RequestFactory()
-        request = rf.get('/api/v1/schools/1/')
+        request = rf.get('/api/v1/schools/1/?fields=teachers')
 
         school = School.objects.create()
         teachers = [
@@ -168,6 +167,5 @@ class TestDynamicFieldsMixin(TestCase):
                         ('request_info', request_info.format(teachers[1].id))
                     ])
                 ],
-                'id': school.id
             }
         )


### PR DESCRIPTION
Right now, when filtering on a field that contains a nested serializer, the value of that field is empty, because the mixin is also applied to sub-serializers.

This change should make sure that filters are only applied to root serializers, or to serializers that are a child of the root and where the root is a list serializer (meaning that many=True).

@jtrain do you think the way this is implemented looks reasonable? (Is this what you already tried to test? I noticed one of the serializers was actually missing the mixin.)