### PR TITLE
Add support for filtering/omitting nested fields based on django style path expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 *.egg-info/
 build/
 .tox/
+VENV/
+.idea/

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -4,7 +4,7 @@ Mixin to dynamically select only a subset of fields per DRF resource.
 import re
 import warnings
 
-_nested_field_pattern = re.compile("__")
+_NESTED_FIELD_PATTERN = re.compile("__")
 
 
 class DynamicFieldsMixin(object):
@@ -45,18 +45,21 @@ class DynamicFieldsMixin(object):
             warnings.warn('Request object does not contain query paramters')
 
         try:
-            filter_fields = self._get_params_for_include_path(current_path, params.get('fields', None).split(','))
+            filter_fields = self._get_params_for_include_path(
+                current_path, params.get('fields', None).split(','))
         except AttributeError:
             filter_fields = None
 
         try:
-            omit_fields = self._get_params_for_omit_path(current_path, params.get('omit', None).split(','))
+            omit_fields = self._get_params_for_omit_path\
+                (current_path, params.get('omit', None).split(','))
         except AttributeError:
             omit_fields = []
 
         # Drop any fields that are not specified in the `fields` argument.
         existing = set(fields.keys())
-        if (len(current_path) == 0 and filter_fields is None) or (len(current_path) > 0 and not filter_fields):
+        if (len(current_path) == 0 and filter_fields is None) or \
+                (len(current_path) > 0 and not filter_fields):
             # no fields param given, don't filter.
             allowed = existing
         else:
@@ -75,7 +78,8 @@ class DynamicFieldsMixin(object):
 
         return fields
 
-    def _get_params_for_include_path(self, current_path, field_names):
+    @classmethod
+    def _get_params_for_include_path(cls, current_path, field_names):
         path = current_path if len(current_path) == 0 else current_path + "__"
         current_fields_pattern = re.compile("^"+re.escape(path)+"(.+?)((?:__).+)?$")
         path_params = set()
@@ -87,7 +91,8 @@ class DynamicFieldsMixin(object):
 
         return path_params
 
-    def _get_params_for_omit_path(self, current_path, field_names):
+    @classmethod
+    def _get_params_for_omit_path(cls, current_path, field_names):
         path = current_path if len(current_path) == 0 else current_path + "__"
         nested = len(path) > 0
         path_params = set()
@@ -95,7 +100,7 @@ class DynamicFieldsMixin(object):
         for name in field_names:
             if not nested or name.startswith(path):
                 field = name if not nested else name.split(path, 1)[1]
-                if not _nested_field_pattern.search(field):
+                if not _NESTED_FIELD_PATTERN.search(field):
                     path_params.add(field)
 
         return path_params

--- a/tests/models.py
+++ b/tests/models.py
@@ -5,11 +5,13 @@ from django.db import models
 
 
 class Pet(models.Model):
+    """Pet model to test nested serializers"""
     name = models.CharField(max_length=50)
     age = models.IntegerField()
 
 
 class Teacher(models.Model):
+    """Optional class pet for this teacher"""
     name = models.CharField(max_length=50, blank=True, null=True)
     class_pet = models.ForeignKey(Pet, blank=True, null=True)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -11,7 +11,7 @@ class Pet(models.Model):
 
 class Teacher(models.Model):
     name = models.CharField(max_length=50, blank=True, null=True)
-    class_pet = models.ForeignKey(Pet, models.SET_NULL, blank=True, null=True)
+    class_pet = models.ForeignKey(Pet, blank=True, null=True)
 
 
 class School(models.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,8 +4,14 @@ Some models for the tests. We are modelling a school.
 from django.db import models
 
 
+class Pet(models.Model):
+    name = models.CharField(max_length=50)
+    age = models.IntegerField()
+
+
 class Teacher(models.Model):
-    """No fields, no fun."""
+    name = models.CharField(max_length=50, blank=True, null=True)
+    class_pet = models.ForeignKey(Pet, models.SET_NULL, blank=True, null=True)
 
 
 class School(models.Model):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -5,7 +5,13 @@ from rest_framework import serializers
 
 from drf_dynamic_fields import DynamicFieldsMixin
 
-from .models import Teacher, School
+from .models import Teacher, School, Pet
+
+
+class PetSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Pet
+        fields = ('id', 'name', 'age')
 
 
 class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
@@ -15,10 +21,11 @@ class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     """
 
     request_info = serializers.SerializerMethodField()
+    class_pet = PetSerializer()
 
     class Meta:
         model = Teacher
-        fields = ('id', 'request_info')
+        fields = ('id', 'name', 'request_info', 'class_pet',)
 
     def get_request_info(self, teacher):
         """

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -9,7 +9,13 @@ from .models import Teacher, School, Pet
 
 
 class PetSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    """
+    Serializer that will be nested to test filtering of nested fields
+    """
     class Meta:
+        """
+        Base off Pet model
+        """
         model = Pet
         fields = ('id', 'name', 'age')
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -174,9 +174,13 @@ class TestDynamicFieldsMixin(TestCase):
             }
         )
 
-    def test_as_nested_serializer_list_with_filter(self):
+    def test_as_nested_list_with_filter(self):
+        """
+        Test filtering on a nested list
+        """
         rf = RequestFactory()
-        request = rf.get('/api/v1/schools/1/?fields=teachers__id,teachers__class_pet__name')
+        request = rf.get(
+            '/api/v1/schools/1/?fields=teachers__id,teachers__class_pet__name')
 
         pet = Pet.objects.create(name="Hamster", age=1)
         school = School.objects.create()
@@ -203,12 +207,14 @@ class TestDynamicFieldsMixin(TestCase):
             }
         )
 
-    def test_as_nested_serializer_list_with_omit(self):
+    def test_as_nested_list_with_omit(self):
         """
         Nested serializers are not filtered, without nested filter paths
         """
         rf = RequestFactory()
-        request = rf.get('/api/v1/schools/1/?omit=teachers__id,teachers__class_pet__id,teachers__class_pet__age')
+        request = rf.get(
+            '/api/v1/schools/1/?omit=teachers__id,teachers__class_pet__id,' +
+            'teachers__class_pet__age')
 
         pet = Pet.objects.create(name="Hamster", age=1)
         school = School.objects.create()
@@ -240,7 +246,10 @@ class TestDynamicFieldsMixin(TestCase):
             }
         )
 
-    def test_with_nested_field_limiting(self):
+    def test_with_nested_field_limit(self):
+        """
+        Test nested scenario limiting top level and nested fields
+        """
         rf = RequestFactory()
         request = rf.get('/api/v1/teacher/1/?fields=id,name,class_pet__age')
 
@@ -262,9 +271,14 @@ class TestDynamicFieldsMixin(TestCase):
             }
         )
 
-    def test_with_nested_field_omitting(self):
+    def test_with_nested_field_omit(self):
+        """
+        Test nested scenario with omit option with both top level and nested
+        fields
+        """
         rf = RequestFactory()
-        request = rf.get('/api/v1/teacher/1/?omit=name,request_info,class_pet__age')
+        request = rf.get(
+            '/api/v1/teacher/1/?omit=name,request_info,class_pet__age')
 
         pet = Pet.objects.create(name="Hamster", age=2)
         teacher = Teacher.objects.create(name="Dr. Smith", class_pet=pet)


### PR DESCRIPTION
This PR attempts to add support for filtering nested fields using standard django style path expressions via the `__` separator.  One of the projects I am working on uses DRF in conjunction with mongoengine and being able to filter the nested fields is important for us as we end up with nested structures quite often that we filter at the mongo layer and without this we end up with fields coming back as null instead of removing them.