### PR TITLE
Only filter outgoing fields

### DIFF
--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -1,6 +1,7 @@
 """
 Mixin to dynamically select only a subset of fields per DRF resource.
 """
+from collections import OrderedDict
 import warnings
 
 from django.utils.functional import cached_property
@@ -14,10 +15,10 @@ class DynamicFieldsMixin(object):
 
     @cached_property
     def _readable_fields_dict(self):
-        return {
-            name: field for name, field in self.fields.items()
+        return OrderedDict(
+            (name, field) for name, field in self.fields.items()
             if not field.write_only
-        }
+        )
 
     @property
     def _readable_fields(self):

--- a/tests/models.py
+++ b/tests/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 
 class Teacher(models.Model):
-    """No fields, no fun."""
+    name = models.CharField(max_length=200)
 
 
 class School(models.Model):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -18,7 +18,7 @@ class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     class Meta:
         model = Teacher
-        fields = ('id', 'request_info')
+        fields = ('id', 'name', 'request_info')
 
     def get_request_info(self, teacher):
         """

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -29,7 +29,7 @@ class TestDynamicFieldsMixin(TestCase):
         serializer = TeacherSerializer(context={'request': request})
 
         self.assertEqual(
-            set(serializer.fields.keys()),
+            set(serializer._filtered_readable_fields_dict().keys()),
             set(('id',))
         )
 
@@ -42,7 +42,7 @@ class TestDynamicFieldsMixin(TestCase):
         serializer = TeacherSerializer(context={'request': request})
 
         self.assertEqual(
-            set(serializer.fields.keys()),
+            set(serializer._filtered_readable_fields_dict().keys()),
             set(('id', 'request_info'))
         )
 
@@ -55,7 +55,7 @@ class TestDynamicFieldsMixin(TestCase):
         serializer = TeacherSerializer(context={'request': request})
 
         self.assertEqual(
-            set(serializer.fields.keys()),
+            set(serializer._filtered_readable_fields_dict().keys()),
             set()
         )
 
@@ -84,7 +84,7 @@ class TestDynamicFieldsMixin(TestCase):
         serializer = TeacherSerializer(context={'request': request})
 
         self.assertEqual(
-            set(serializer.fields.keys()),
+            set(serializer._filtered_readable_fields_dict().keys()),
             set(('id',))
         )
 
@@ -97,7 +97,7 @@ class TestDynamicFieldsMixin(TestCase):
         serializer = TeacherSerializer(context={'request': request})
 
         self.assertEqual(
-            set(serializer.fields.keys()),
+            set(serializer._filtered_readable_fields_dict().keys()),
             set(('id',))
         )
 
@@ -110,7 +110,7 @@ class TestDynamicFieldsMixin(TestCase):
         serializer = TeacherSerializer(context={'request': request})
 
         self.assertEqual(
-            set(serializer.fields.keys()),
+            set(serializer._filtered_readable_fields_dict().keys()),
             set()
         )
 
@@ -123,7 +123,7 @@ class TestDynamicFieldsMixin(TestCase):
         serializer = TeacherSerializer(context={'request': request})
 
         self.assertEqual(
-            set(serializer.fields.keys()),
+            set(serializer._filtered_readable_fields_dict().keys()),
             set(('id', 'request_info'))
         )
 
@@ -133,7 +133,7 @@ class TestDynamicFieldsMixin(TestCase):
         serializer = TeacherSerializer(context={'request': request})
 
         self.assertEqual(
-            set(serializer.fields.keys()),
+            set(serializer._filtered_readable_fields_dict().keys()),
             set(('id', 'request_info'))
         )
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8
-"""
-Empty urls for test.
-"""
-urlpatterns = []  # noqa.
+
+from django.conf.urls import url, include
+from rest_framework import routers
+from . import views
+
+router = routers.DefaultRouter()
+router.register('teachers', views.TeacherViewSet)
+router.register('schools', views.SchoolViewSet)
+
+urlpatterns = [
+    url(r'^api/v1/', include(router.urls)),
+]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,0 +1,13 @@
+from .models import School, Teacher
+from rest_framework import viewsets
+from .serializers import TeacherSerializer, SchoolSerializer
+
+
+class TeacherViewSet(viewsets.ModelViewSet):
+    queryset = Teacher.objects.all()
+    serializer_class = TeacherSerializer
+
+
+class SchoolViewSet(viewsets.ModelViewSet):
+    queryset = School.objects.all()
+    serializer_class = SchoolSerializer


### PR DESCRIPTION
I'd like to be able to use `?fields` on a `POST` but currently what happens is the incoming data is filtered as well as the outgoing data so fields sent up are ignored.  I'd like to have all the fields present as usual when the serializer is doing `to_internal_value` and only filter for `to_representation`.  This way you can POST the full object and only have what's returned filtered.

Does this make sense?  Is it something every use case would want?