### PR TITLE
Adding cached_property to the fields method

### DIFF
--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -4,6 +4,7 @@ Mixin to dynamically select only a subset of fields per DRF resource.
 import warnings
 
 from django.conf import settings
+from django.utils.functional import cached_property
 
 
 class DynamicFieldsMixin(object):
@@ -12,7 +13,7 @@ class DynamicFieldsMixin(object):
     which fields should be displayed.
     """
 
-    @property
+    @cached_property
     def fields(self):
         """
         Filters the fields according to the `fields` query parameter.


### PR DESCRIPTION
Hi,

A cache is added to the fields method, when it is used to serialize more than 10,000 items, it can achieve a performance of up to 10x in the response time of the endpoint.

This cached is based on rest framework serializer.