### PR TITLE
Added support to filter nested fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.egg-info/
 build/
 .tox/
+.idea

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -1,8 +1,10 @@
 """
 Mixin to dynamically select only a subset of fields per DRF resource.
 """
+
 import warnings
 
+from collections import defaultdict
 from django.conf import settings
 from django.utils.functional import cached_property
 
@@ -20,7 +22,7 @@ class DynamicFieldsMixin(object):
 
         A blank `fields` parameter (?fields) will remove all fields. Not
         passing `fields` will pass all fields individual fields are comma
-        separated (?fields=id,name,url,email).
+        separated (?fields=id,name,url,email,teachers__age).
 
         """
         fields = super(DynamicFieldsMixin, self).fields
@@ -58,7 +60,7 @@ class DynamicFieldsMixin(object):
         try:
             filter_fields = params.get("fields", None).split(",")
         except AttributeError:
-            filter_fields = None
+            filter_fields = []
 
         try:
             omit_fields = params.get("omit", None).split(",")
@@ -66,15 +68,38 @@ class DynamicFieldsMixin(object):
             omit_fields = []
 
         # Drop any fields that are not specified in the `fields` argument.
+        self._nested_allow = defaultdict(list)
+        self._nested_omit = defaultdict(list)
+        self._flat_allow = set()
+        self._flat_omit = set()
+
+        # store top-level and nested fields specified in the `fields` argument.
+        for filtered_field in filter_fields:
+            if "__" in filtered_field:
+                parent, child = filtered_field.split("__", 1)
+                self._nested_allow[parent].append(child)
+                # If a nested field is allowed the related parent level field
+                # must also be allowed
+                self._flat_allow.add(parent)
+            else:
+                self._flat_allow.add(filtered_field)
+
+        # store top-level and nested fields in the `omit` argument.
+        for omitted_field in omit_fields:
+            if "__" in omitted_field:
+                parent, child = omitted_field.split("__", 1)
+                self._nested_omit[parent].append(child)
+            else:
+                self._flat_omit.add(omitted_field)
+
+        # Drop top-level fields
         existing = set(fields.keys())
-        if filter_fields is None:
+        if "fields" in params:
+            allowed = self._flat_allow
+        else:
             # no fields param given, don't filter.
             allowed = existing
-        else:
-            allowed = set(filter(None, filter_fields))
-
-        # omit fields in the `omit` argument.
-        omitted = set(filter(None, omit_fields))
+        omitted = self._flat_omit
 
         for field in existing:
 
@@ -84,4 +109,152 @@ class DynamicFieldsMixin(object):
             if field in omitted:
                 fields.pop(field, None)
 
+        # Drop omitted and non-allowed child fields from nested serializers
+        self.prune_nested_fields(fields)
+
         return fields
+
+    @staticmethod
+    def _get_nested_serializer(parent, fields):
+        """Return the nested serializer for a parent field, or None."""
+        field = fields.get(parent)
+        if not field:
+            return None
+        nested = getattr(field, "child", field)
+        return nested if hasattr(nested, "fields") else None
+
+    def prune_nested_fields(self, fields):
+        """Prune valid nested serializer fields based on the _nested_omit and _nested_allow lists."""
+        valid_parents = (
+            self._nested_omit.keys() | self._nested_allow.keys()
+        ) & fields.keys()
+        for parent in valid_parents:
+            nested_serializer = self._get_nested_serializer(parent, fields)
+            if nested_serializer is None:
+                continue
+
+            # Drop omitted child fields from nested serializers
+            for name in self._nested_omit.get(parent, ()):
+                nested_serializer.fields.pop(name, None)
+
+            # Drop non-allowed child fields from the nested serializers
+            allow_list = self._nested_allow.get(parent)
+            if allow_list:
+                nested_serializer.fields = {
+                    name: field
+                    for name, field in nested_serializer.fields.items()
+                    if name in allow_list
+                }
+
+    def _filter_top_level_fields_to_defer(self, field_list, keep_if):
+        """Method to retrieve the top-level fields to defer, given a list of
+        field names (allow or omit) and a condition that determines which
+        fields to defer.
+        """
+        model = getattr(self.Meta, "model", None)
+        if not field_list or model is None:
+            return []
+
+        all_fields = [
+            f.name for f in model._meta.get_fields() if getattr(f, "concrete", False)
+        ]
+        return [name for name in all_fields if keep_if(name, field_list)]
+
+    def _get_disallowed_top_level_fields_to_defer(self):
+        """Determine which top-level model fields should be deferred when an
+        explicit fields filter is in use.
+        Other model fields not explicitly included in 'fields' are deferred.
+        """
+        allow = getattr(self, "_flat_allow", None)
+        return self._filter_top_level_fields_to_defer(
+            allow, keep_if=lambda name, allow: name not in allow
+        )
+
+    def _get_omit_top_level_fields_to_defer(self):
+        """
+        Determine which top-level model fields should be deferred when an
+        explicit omit filter is in use. Valid database fields in the omit list
+        will be deferred.
+        """
+        omit = getattr(self, "_flat_omit", None)
+        return self._filter_top_level_fields_to_defer(
+            omit, keep_if=lambda name, omit: name in omit
+        )
+
+    def _get_nested_level_fields_to_defer(self, nested_mapping, should_defer):
+        """Method to retrieve nested fields to defer based on a mapping and a
+        defer condition.
+        """
+        fields_to_defer = []
+        for parent, items in nested_mapping.items():
+            field = self.fields.get(parent)
+            if not field:
+                continue
+
+            child_serializer = getattr(field, "child", field)
+            nested_model = getattr(child_serializer.Meta, "model", None)
+            if nested_model is None:
+                continue
+
+            # Filter out nested fields that have a database column associated
+            # with them.
+            field_names = [
+                f.name
+                for f in nested_model._meta.get_fields()
+                if getattr(f, "concrete", False)
+            ]
+
+            # Determine which nested fields to defer
+            for name in field_names:
+                if should_defer(name, items):
+                    fields_to_defer.append(f"{parent}__{name}")
+
+        return fields_to_defer
+
+    def _get_disallowed_nested_level_fields_to_defer(self):
+        """Determine which top-level model fields should be deferred when an
+         explicit fields filter is in use.
+        Other model fields not explicitly included in 'fields' are deferred.
+        """
+        allow_map = getattr(self, "_nested_allow", {})
+        return self._get_nested_level_fields_to_defer(
+            allow_map,
+            should_defer=lambda name, allow_list: name not in allow_list,
+        )
+
+    def _get_omit_nested_level_fields_to_defer(self):
+        """
+        Determine which nested-model fields should be deferred for each nested
+        serializer when an explicit omit filter is in use.
+        """
+        omit_map = getattr(self, "_nested_omit", {})
+        return self._get_nested_level_fields_to_defer(
+            omit_map, should_defer=lambda name, omit_list: name in omit_list
+        )
+
+    def get_model_fields_to_defer(self):
+        """
+        Returns a flat list of filtered model-fields; top-level and nested.
+        Ensures that parsing of 'fields'/'omit' has run by accessing '.fields'.
+        """
+
+        # Trigger parsing of required attributes if not already set
+        if not all(
+            hasattr(self, attr)
+            for attr in (
+                "_flat_omit",
+                "_nested_omit",
+                "_flat_allow",
+                "_nested_allow",
+            )
+        ):
+            _ = self.fields
+
+        deferred = [
+            *self._get_omit_top_level_fields_to_defer(),
+            *self._get_omit_nested_level_fields_to_defer(),
+            *self._get_disallowed_top_level_fields_to_defer(),
+            *self._get_disallowed_nested_level_fields_to_defer(),
+        ]
+        # Remove any duplicate fields
+        return list(set(deferred))

--- a/drf_dynamic_fields/__init__.py
+++ b/drf_dynamic_fields/__init__.py
@@ -4,9 +4,10 @@ Mixin to dynamically select only a subset of fields per DRF resource.
 
 import warnings
 
-from collections import defaultdict
 from django.conf import settings
 from django.utils.functional import cached_property
+
+from rest_framework import serializers
 
 
 class DynamicFieldsMixin(object):
@@ -15,6 +16,15 @@ class DynamicFieldsMixin(object):
     which fields should be displayed.
     """
 
+    @property
+    def is_preventing_nested_serializers(self):
+        is_root = self.root == self
+        parent_is_list_root = self.parent == self.root and getattr(
+            self.parent, "many", False
+        )
+
+        return not (is_root or parent_is_list_root)
+
     @cached_property
     def fields(self):
         """
@@ -22,7 +32,7 @@ class DynamicFieldsMixin(object):
 
         A blank `fields` parameter (?fields) will remove all fields. Not
         passing `fields` will pass all fields individual fields are comma
-        separated (?fields=id,name,url,email,teachers__age).
+        separated (?fields=id,name,url,email).
 
         """
         fields = super(DynamicFieldsMixin, self).fields
@@ -31,13 +41,7 @@ class DynamicFieldsMixin(object):
             # We are being called before a request cycle
             return fields
 
-        # Only filter if this is the root serializer, or if the parent is the
-        # root serializer with many=True
-        is_root = self.root == self
-        parent_is_list_root = self.parent == self.root and getattr(
-            self.parent, "many", False
-        )
-        if not (is_root or parent_is_list_root):
+        if self.is_preventing_nested_serializers:
             return fields
 
         try:
@@ -57,49 +61,22 @@ class DynamicFieldsMixin(object):
         if params is None:
             warnings.warn("Request object does not contain query parameters")
 
-        try:
-            filter_fields = params.get("fields", None).split(",")
-        except AttributeError:
-            filter_fields = []
+        source = get_source_path(self)
+        level = compute_level(self)
 
-        try:
-            omit_fields = params.get("omit", None).split(",")
-        except AttributeError:
-            omit_fields = []
+        filter_fields = self.get_filter_fields(params.get("fields", None), level, source)
+        omit_fields = self.get_omit_fields(params.get("omit", None), level, source)
 
         # Drop any fields that are not specified in the `fields` argument.
-        self._nested_allow = defaultdict(list)
-        self._nested_omit = defaultdict(list)
-        self._flat_allow = set()
-        self._flat_omit = set()
-
-        # store top-level and nested fields specified in the `fields` argument.
-        for filtered_field in filter_fields:
-            if "__" in filtered_field:
-                parent, child = filtered_field.split("__", 1)
-                self._nested_allow[parent].append(child)
-                # If a nested field is allowed the related parent level field
-                # must also be allowed
-                self._flat_allow.add(parent)
-            else:
-                self._flat_allow.add(filtered_field)
-
-        # store top-level and nested fields in the `omit` argument.
-        for omitted_field in omit_fields:
-            if "__" in omitted_field:
-                parent, child = omitted_field.split("__", 1)
-                self._nested_omit[parent].append(child)
-            else:
-                self._flat_omit.add(omitted_field)
-
-        # Drop top-level fields
         existing = set(fields.keys())
-        if "fields" in params:
-            allowed = self._flat_allow
-        else:
+        if filter_fields is None:
             # no fields param given, don't filter.
             allowed = existing
-        omitted = self._flat_omit
+        else:
+            allowed = set(filter(None, filter_fields))
+
+        # omit fields in the `omit` argument.
+        omitted = set(filter(None, omit_fields))
 
         for field in existing:
 
@@ -109,152 +86,74 @@ class DynamicFieldsMixin(object):
             if field in omitted:
                 fields.pop(field, None)
 
-        # Drop omitted and non-allowed child fields from nested serializers
-        self.prune_nested_fields(fields)
-
         return fields
 
-    @staticmethod
-    def _get_nested_serializer(parent, fields):
-        """Return the nested serializer for a parent field, or None."""
-        field = fields.get(parent)
-        if not field:
-            return None
-        nested = getattr(field, "child", field)
-        return nested if hasattr(nested, "fields") else None
+    def get_filter_fields(self, params, level, source, default=None, include_parent=True):
+        try:
+            return params.split(",")
+        except AttributeError:
+            return default
 
-    def prune_nested_fields(self, fields):
-        """Prune valid nested serializer fields based on the _nested_omit and _nested_allow lists."""
-        valid_parents = (
-            self._nested_omit.keys() | self._nested_allow.keys()
-        ) & fields.keys()
-        for parent in valid_parents:
-            nested_serializer = self._get_nested_serializer(parent, fields)
-            if nested_serializer is None:
-                continue
 
-            # Drop omitted child fields from nested serializers
-            for name in self._nested_omit.get(parent, ()):
-                nested_serializer.fields.pop(name, None)
+    def get_omit_fields(self, params, level, source):
+        return self.get_filter_fields(params, level, source, default=[], include_parent=False)
 
-            # Drop non-allowed child fields from the nested serializers
-            allow_list = self._nested_allow.get(parent)
-            if allow_list:
-                nested_serializer.fields = {
-                    name: field
-                    for name, field in nested_serializer.fields.items()
-                    if name in allow_list
-                }
 
-    def _filter_top_level_fields_to_defer(self, field_list, keep_if):
-        """Method to retrieve the top-level fields to defer, given a list of
-        field names (allow or omit) and a condition that determines which
-        fields to defer.
-        """
-        model = getattr(self.Meta, "model", None)
-        if not field_list or model is None:
-            return []
+class NestedDynamicFieldsMixin(DynamicFieldsMixin):
 
-        all_fields = [
-            f.name for f in model._meta.get_fields() if getattr(f, "concrete", False)
-        ]
-        return [name for name in all_fields if keep_if(name, field_list)]
+    @property
+    def is_preventing_nested_serializers(self):
+        return False
 
-    def _get_disallowed_top_level_fields_to_defer(self):
-        """Determine which top-level model fields should be deferred when an
-        explicit fields filter is in use.
-        Other model fields not explicitly included in 'fields' are deferred.
-        """
-        allow = getattr(self, "_flat_allow", None)
-        return self._filter_top_level_fields_to_defer(
-            allow, keep_if=lambda name, allow: name not in allow
-        )
-
-    def _get_omit_top_level_fields_to_defer(self):
-        """
-        Determine which top-level model fields should be deferred when an
-        explicit omit filter is in use. Valid database fields in the omit list
-        will be deferred.
-        """
-        omit = getattr(self, "_flat_omit", None)
-        return self._filter_top_level_fields_to_defer(
-            omit, keep_if=lambda name, omit: name in omit
-        )
-
-    def _get_nested_level_fields_to_defer(self, nested_mapping, should_defer):
-        """Method to retrieve nested fields to defer based on a mapping and a
-        defer condition.
-        """
-        fields_to_defer = []
-        for parent, items in nested_mapping.items():
-            field = self.fields.get(parent)
-            if not field:
-                continue
-
-            child_serializer = getattr(field, "child", field)
-            nested_model = getattr(child_serializer.Meta, "model", None)
-            if nested_model is None:
-                continue
-
-            # Filter out nested fields that have a database column associated
-            # with them.
-            field_names = [
-                f.name
-                for f in nested_model._meta.get_fields()
-                if getattr(f, "concrete", False)
-            ]
-
-            # Determine which nested fields to defer
-            for name in field_names:
-                if should_defer(name, items):
-                    fields_to_defer.append(f"{parent}__{name}")
-
-        return fields_to_defer
-
-    def _get_disallowed_nested_level_fields_to_defer(self):
-        """Determine which top-level model fields should be deferred when an
-         explicit fields filter is in use.
-        Other model fields not explicitly included in 'fields' are deferred.
-        """
-        allow_map = getattr(self, "_nested_allow", {})
-        return self._get_nested_level_fields_to_defer(
-            allow_map,
-            should_defer=lambda name, allow_list: name not in allow_list,
-        )
-
-    def _get_omit_nested_level_fields_to_defer(self):
-        """
-        Determine which nested-model fields should be deferred for each nested
-        serializer when an explicit omit filter is in use.
-        """
-        omit_map = getattr(self, "_nested_omit", {})
-        return self._get_nested_level_fields_to_defer(
-            omit_map, should_defer=lambda name, omit_list: name in omit_list
-        )
-
-    def get_model_fields_to_defer(self):
-        """
-        Returns a flat list of filtered model-fields; top-level and nested.
-        Ensures that parsing of 'fields'/'omit' has run by accessing '.fields'.
-        """
-
-        # Trigger parsing of required attributes if not already set
-        if not all(
-            hasattr(self, attr)
-            for attr in (
-                "_flat_omit",
-                "_nested_omit",
-                "_flat_allow",
-                "_nested_allow",
+    def get_filter_fields(self, params, level, source, default=None, include_parent=True):
+        fields = super().get_filter_fields(params, level, source, default, include_parent)
+        return get_fields_for_level_and_prefix(
+                fields,
+                level,
+                source,
+                default=default,
+                include_parent=include_parent
             )
-        ):
-            _ = self.fields
 
-        deferred = [
-            *self._get_omit_top_level_fields_to_defer(),
-            *self._get_omit_nested_level_fields_to_defer(),
-            *self._get_disallowed_top_level_fields_to_defer(),
-            *self._get_disallowed_nested_level_fields_to_defer(),
-        ]
-        # Remove any duplicate fields
-        return list(set(deferred))
+def get_source_path(serializer):
+    parts = []
+    current = serializer
+    while current.parent is not None:
+        if hasattr(current, 'field_name'):
+            parts.insert(0, current.field_name)
+        current = current.parent
+    return "__".join(filter(None, parts))
+
+def get_fields_for_level_and_prefix(fields_list, level, source, include_parent, default):
+    if not fields_list:
+        return default
+
+    allowed = set()
+    prefix = source.split("__") if source else []
+    for f in fields_list:
+        parts = f.split("__")
+        if parts[:level] != prefix:
+            continue
+        if len(parts) <= level + 1:
+            allowed.add(parts[-1])
+        elif len(parts) > level + 1 and include_parent:
+            # include parent field to ensure nesting proceeds
+            allowed.add(parts[level])
+    if set(prefix) == allowed:
+        return default
+    return allowed
+
+def compute_level(serializer):
+    level = 0
+    current = serializer
+    while hasattr(current, 'parent') and current.parent is not None:
+        parent = current.parent
+
+        # Handle ListSerializer by skipping over it
+        if isinstance(parent, serializers.ListSerializer):
+            current = parent.parent
+        else:
+            current = parent
+
+        level += 1
+    return level

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,3 +14,12 @@ class School(models.Model):
 
     name = models.CharField(max_length=30)
     teachers = models.ManyToManyField(Teacher)
+
+
+class Child(models.Model):
+    secret = models.CharField(max_length=100)
+    public = models.CharField(max_length=100)
+
+
+class Parent(models.Model):
+    child = models.ForeignKey(Child, on_delete=models.CASCADE)

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -3,16 +3,12 @@ For the tests.
 """
 from rest_framework import serializers
 
-from drf_dynamic_fields import DynamicFieldsMixin
+from drf_dynamic_fields import DynamicFieldsMixin, NestedDynamicFieldsMixin
 
 from .models import Teacher, School, Child
 
 
-class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
-    """
-    The request_info field is to highlight the issue accessing request during
-    a nested serializer.
-    """
+class BaseTeacherSerializer(serializers.ModelSerializer):
 
     request_info = serializers.SerializerMethodField()
 
@@ -29,20 +25,37 @@ class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         return request.build_absolute_uri("/api/v1/teacher/{}".format(teacher.pk))
 
 
-class SchoolSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class TeacherSerializer(DynamicFieldsMixin, BaseTeacherSerializer):
+    pass
+
+
+class NestableTeacherSerializer(NestedDynamicFieldsMixin, BaseTeacherSerializer):
     """
-    Interesting enough serializer because the TeacherSerializer
-    will use ListSerializer due to the `many=True`
+    The request_info field is to highlight the issue accessing request during
+    a nested serializer.
+
     """
 
-    teachers = TeacherSerializer(many=True, read_only=True)
+class BaseSchoolSerializer(serializers.ModelSerializer):
+
 
     class Meta:
         model = School
         fields = ("id", "teachers", "name")
 
 
-class ChildSerializer(DynamicFieldsMixin, serializers.Serializer):
+class SchoolSerializer(DynamicFieldsMixin, BaseSchoolSerializer):
+    teachers = TeacherSerializer(many=True, read_only=True)
+
+
+class NestableSchoolSerializer(NestedDynamicFieldsMixin, BaseSchoolSerializer):
+    """
+    Interesting enough serializer because the TeacherSerializer
+    will use ListSerializer due to the `many=True`
+    """
+    teachers = NestableTeacherSerializer(many=True, read_only=True)
+
+class ChildSerializer(NestedDynamicFieldsMixin, serializers.Serializer):
     secret = serializers.CharField()
     public = serializers.CharField()
 
@@ -50,6 +63,6 @@ class ChildSerializer(DynamicFieldsMixin, serializers.Serializer):
         model = Child
 
 
-class ParentSerializer(DynamicFieldsMixin, serializers.Serializer):
+class ParentSerializer(NestedDynamicFieldsMixin, serializers.Serializer):
     id = serializers.IntegerField()
     child = ChildSerializer()

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 
 from drf_dynamic_fields import DynamicFieldsMixin
 
-from .models import Teacher, School
+from .models import Teacher, School, Child
 
 
 class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
@@ -40,3 +40,16 @@ class SchoolSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = School
         fields = ("id", "teachers", "name")
+
+
+class ChildSerializer(DynamicFieldsMixin, serializers.Serializer):
+    secret = serializers.CharField()
+    public = serializers.CharField()
+
+    class Meta:
+        model = Child
+
+
+class ParentSerializer(DynamicFieldsMixin, serializers.Serializer):
+    id = serializers.IntegerField()
+    child = ChildSerializer()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -11,7 +11,13 @@ from collections import OrderedDict
 
 from django.test import TestCase, RequestFactory
 
-from .serializers import SchoolSerializer, TeacherSerializer, ParentSerializer
+from .serializers import (
+    NestableSchoolSerializer,
+    NestableTeacherSerializer,
+    SchoolSerializer,
+    TeacherSerializer,
+    ParentSerializer,
+)
 from .models import Teacher, School, Child, Parent
 
 
@@ -20,36 +26,8 @@ class TestDynamicFieldsMixin(TestCase):
     Test case for the DynamicFieldsMixin
     """
 
-    def _assert_nested_fields(self, data, expected_fields):
-        """
-        Assert nested fields match the expected fields.
-        """
-        for parent, nested_fields in expected_fields.items():
-            with self.subTest(parent=parent):
-                items = data[parent]
-                if nested_fields is None:
-                    continue
-                expected_set = set(nested_fields)
-                for obj in items:
-                    with self.subTest(parent=parent):
-                        actual_set = set(obj.keys())
-                        self.assertEqual(
-                            actual_set,
-                            expected_set,
-                            f"{parent} fields mismatch: expected "
-                            f"exactly {nested_fields}, got {list(obj.keys())}",
-                        )
-
-    @staticmethod
-    def _prepare_school_instance():
-        """Prepare school instance for testing."""
-        school = School.objects.create(name="Python Heights High")
-        teachers = [
-            Teacher.objects.create(name="Shane", age=45),
-            Teacher.objects.create(name="Kaz", age=29),
-        ]
-        school.teachers.add(*teachers)
-        return school
+    SchoolSerializer = SchoolSerializer
+    TeacherSerializer = TeacherSerializer
 
     def test_removes_fields(self):
         """
@@ -57,7 +35,7 @@ class TestDynamicFieldsMixin(TestCase):
         """
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?fields=id")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
 
         self.assertEqual(set(serializer.fields.keys()), set(("id",)))
 
@@ -67,7 +45,7 @@ class TestDynamicFieldsMixin(TestCase):
         """
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
 
         self.assertEqual(
             set(serializer.fields.keys()), set(("id", "request_info", "age", "name"))
@@ -79,7 +57,7 @@ class TestDynamicFieldsMixin(TestCase):
         """
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?fields")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
 
         self.assertEqual(set(serializer.fields.keys()), set())
 
@@ -91,7 +69,7 @@ class TestDynamicFieldsMixin(TestCase):
         request = rf.get("/api/v1/schools/1/?fields=id,age")
         teacher = Teacher.objects.create(name="Susan", age=34)
 
-        serializer = TeacherSerializer(teacher, context={"request": request})
+        serializer = self.TeacherSerializer(teacher, context={"request": request})
 
         self.assertEqual(serializer.data, {"id": teacher.id, "age": teacher.age})
 
@@ -101,7 +79,7 @@ class TestDynamicFieldsMixin(TestCase):
         """
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?omit=request_info")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
 
         self.assertEqual(set(serializer.fields.keys()), set(("id", "name", "age")))
 
@@ -111,7 +89,7 @@ class TestDynamicFieldsMixin(TestCase):
         """
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?fields=id,request_info&omit=request_info")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
 
         self.assertEqual(set(serializer.fields.keys()), set(("id",)))
 
@@ -121,7 +99,7 @@ class TestDynamicFieldsMixin(TestCase):
         """
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?omit=id,request_info,age,name")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
 
         self.assertEqual(set(serializer.fields.keys()), set())
 
@@ -131,7 +109,7 @@ class TestDynamicFieldsMixin(TestCase):
         """
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?omit")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
 
         self.assertEqual(
             set(serializer.fields.keys()), set(("id", "request_info", "name", "age"))
@@ -140,7 +118,7 @@ class TestDynamicFieldsMixin(TestCase):
     def test_omit_non_existant_field(self):
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?omit=pretend")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
 
         self.assertEqual(
             set(serializer.fields.keys()), set(("id", "request_info", "name", "age"))
@@ -160,7 +138,7 @@ class TestDynamicFieldsMixin(TestCase):
         ]
         school.teachers.add(*teachers)
 
-        serializer = SchoolSerializer(school, context={"request": request})
+        serializer = self.SchoolSerializer(school, context={"request": request})
 
         request_info = "http://testserver/api/v1/teacher/{}"
 
@@ -199,7 +177,7 @@ class TestDynamicFieldsMixin(TestCase):
 
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?fields=id")
-        serializer = TeacherSerializer(context={"request": request})
+        serializer = self.TeacherSerializer(context={"request": request})
         self.assertEqual(set(serializer.fields.keys()), {"id"})
 
         # now change the request on this instantiated serializer.
@@ -207,13 +185,51 @@ class TestDynamicFieldsMixin(TestCase):
         serializer.context["request"] = request2
         self.assertEqual(set(serializer.fields.keys()), {"id"})
 
+class TestNestedDynamicFieldsMixin(TestDynamicFieldsMixin):
+    """
+    Test case for the NestedDynamicFieldsMixin
+    """
+    SchoolSerializer = NestableSchoolSerializer
+    TeacherSerializer = NestableTeacherSerializer
+
+    def _assert_nested_fields(self, data, expected_fields):
+        """
+        Assert nested fields match the expected fields.
+        """
+        for parent, nested_fields in expected_fields.items():
+            with self.subTest(parent=parent):
+                items = data[parent]
+                if nested_fields is None:
+                    continue
+                expected_set = set(nested_fields)
+                for obj in items:
+                    with self.subTest(parent=parent):
+                        actual_set = set(obj.keys())
+                        self.assertEqual(
+                            actual_set,
+                            expected_set,
+                            f"{parent} fields mismatch: expected "
+                            f"exactly {nested_fields}, got {list(obj.keys())}",
+                        )
+
+    @staticmethod
+    def _prepare_school_instance():
+        """Prepare school instance for testing."""
+        school = School.objects.create(name="Python Heights High")
+        teachers = [
+            Teacher.objects.create(name="Shane", age=45),
+            Teacher.objects.create(name="Kaz", age=29),
+        ]
+        school.teachers.add(*teachers)
+        return school
+
     def test_omit_nested_field(self):
         """Omitting a nested field"""
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?omit=invalid,name,teachers__age,teachers__invalid")
 
         school = self._prepare_school_instance()
-        serializer = SchoolSerializer(school, context={"request": request})
+        serializer = self.SchoolSerializer(school, context={"request": request})
         data = serializer.data
 
         # Confirm omitted fields are in deferred list
@@ -235,7 +251,7 @@ class TestDynamicFieldsMixin(TestCase):
         )
 
         school = self._prepare_school_instance()
-        serializer = SchoolSerializer(school, context={"request": request})
+        serializer = self.SchoolSerializer(school, context={"request": request})
         data = serializer.data
 
         expected_fields = {"id": None, "name": None, "teachers": []}
@@ -251,7 +267,7 @@ class TestDynamicFieldsMixin(TestCase):
         request = rf.get("/api/v1/schools/1/?omit=name")
 
         school = self._prepare_school_instance()
-        serializer = SchoolSerializer(school, context={"request": request})
+        serializer = self.SchoolSerializer(school, context={"request": request})
         data = serializer.data
 
         expected_fields = {
@@ -269,7 +285,7 @@ class TestDynamicFieldsMixin(TestCase):
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?fields=invalid,id,teachers__age,teachers__invalid")
         school = self._prepare_school_instance()
-        serializer = SchoolSerializer(school, context={"request": request})
+        serializer = self.SchoolSerializer(school, context={"request": request})
 
         # Confirm omitted fields are in deferred list
         deferred = set(serializer.get_model_fields_to_defer())
@@ -290,7 +306,7 @@ class TestDynamicFieldsMixin(TestCase):
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?fields")
         school = self._prepare_school_instance()
-        serializer = SchoolSerializer(school, context={"request": request})
+        serializer = self.SchoolSerializer(school, context={"request": request})
 
         data = serializer.data
         expected_fields = {}
@@ -307,7 +323,7 @@ class TestDynamicFieldsMixin(TestCase):
             "/api/v1/schools/1/?fields=id,name,teachers__name,teachers__age&omit=name,teachers__name"
         )
         school = self._prepare_school_instance()
-        serializer = SchoolSerializer(school, context={"request": request})
+        serializer = self.SchoolSerializer(school, context={"request": request})
 
         data = serializer.data
         expected_fields = {"id": None, "teachers": ["age"]}
@@ -324,7 +340,7 @@ class TestDynamicFieldsMixin(TestCase):
         rf = RequestFactory()
         request = rf.get("/api/v1/schools/1/?omit")
         school = self._prepare_school_instance()
-        serializer = SchoolSerializer(school, context={"request": request})
+        serializer = self.SchoolSerializer(school, context={"request": request})
 
         data = serializer.data
         expected_fields = {
@@ -364,3 +380,5 @@ class TestDynamicFieldsMixin(TestCase):
         self.assertIn("secret", data["child"])
         self.assertEqual(data["child"]["secret"], "secret_key")
         self.assertNotIn("public", data["child"])
+
+

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -11,14 +11,45 @@ from collections import OrderedDict
 
 from django.test import TestCase, RequestFactory
 
-from .serializers import SchoolSerializer, TeacherSerializer
-from .models import Teacher, School
+from .serializers import SchoolSerializer, TeacherSerializer, ParentSerializer
+from .models import Teacher, School, Child, Parent
 
 
 class TestDynamicFieldsMixin(TestCase):
     """
     Test case for the DynamicFieldsMixin
     """
+
+    def _assert_nested_fields(self, data, expected_fields):
+        """
+        Assert nested fields match the expected fields.
+        """
+        for parent, nested_fields in expected_fields.items():
+            with self.subTest(parent=parent):
+                items = data[parent]
+                if nested_fields is None:
+                    continue
+                expected_set = set(nested_fields)
+                for obj in items:
+                    with self.subTest(parent=parent):
+                        actual_set = set(obj.keys())
+                        self.assertEqual(
+                            actual_set,
+                            expected_set,
+                            f"{parent} fields mismatch: expected "
+                            f"exactly {nested_fields}, got {list(obj.keys())}",
+                        )
+
+    @staticmethod
+    def _prepare_school_instance():
+        """Prepare school instance for testing."""
+        school = School.objects.create(name="Python Heights High")
+        teachers = [
+            Teacher.objects.create(name="Shane", age=45),
+            Teacher.objects.create(name="Kaz", age=29),
+        ]
+        school.teachers.add(*teachers)
+        return school
 
     def test_removes_fields(self):
         """
@@ -175,3 +206,161 @@ class TestDynamicFieldsMixin(TestCase):
         request2 = rf.get("/api/v1/schools/1/?fields=id,name")
         serializer.context["request"] = request2
         self.assertEqual(set(serializer.fields.keys()), {"id"})
+
+    def test_omit_nested_field(self):
+        """Omitting a nested field"""
+        rf = RequestFactory()
+        request = rf.get("/api/v1/schools/1/?omit=invalid,name,teachers__age,teachers__invalid")
+
+        school = self._prepare_school_instance()
+        serializer = SchoolSerializer(school, context={"request": request})
+        data = serializer.data
+
+        # Confirm omitted fields are in deferred list
+        deferred = set(serializer.get_model_fields_to_defer())
+        self.assertEqual({"name", "teachers__age"}, deferred)
+
+        expected_fields = {"id": None, "teachers": ["id", "name", "request_info"]}
+        # Assert top‐level keys exactly match
+        self.assertEqual(set(data.keys()), set(expected_fields.keys()))
+
+        # Assert nested fields.
+        self._assert_nested_fields(data, expected_fields)
+
+    def test_omit_everything_nested_field(self):
+        """Omitting all fields within a nested field"""
+        rf = RequestFactory()
+        request = rf.get(
+            "/api/v1/schools/1/?omit=teachers__id,teachers__age,teachers__name,teachers__request_info"
+        )
+
+        school = self._prepare_school_instance()
+        serializer = SchoolSerializer(school, context={"request": request})
+        data = serializer.data
+
+        expected_fields = {"id": None, "name": None, "teachers": []}
+        # Assert top‐level keys exactly match
+        self.assertEqual(set(data.keys()), set(expected_fields.keys()))
+
+        # Assert nested fields.
+        self._assert_nested_fields(data, expected_fields)
+
+    def test_omit_top_field_and_keep_all_nested_fields(self):
+        """Omitting a top-level field while keeping all nested fields"""
+        rf = RequestFactory()
+        request = rf.get("/api/v1/schools/1/?omit=name")
+
+        school = self._prepare_school_instance()
+        serializer = SchoolSerializer(school, context={"request": request})
+        data = serializer.data
+
+        expected_fields = {
+            "id": None,
+            "teachers": ["id", "name", "request_info", "age"],
+        }
+        # Assert top‐level keys exactly match
+        self.assertEqual(set(data.keys()), set(expected_fields.keys()))
+
+        # Assert nested fields.
+        self._assert_nested_fields(data, expected_fields)
+
+    def test_allow_nested_field(self):
+        """Select only the requested fields, including nested-level fields."""
+        rf = RequestFactory()
+        request = rf.get("/api/v1/schools/1/?fields=invalid,id,teachers__age,teachers__invalid")
+        school = self._prepare_school_instance()
+        serializer = SchoolSerializer(school, context={"request": request})
+
+        # Confirm omitted fields are in deferred list
+        deferred = set(serializer.get_model_fields_to_defer())
+        self.assertEqual({"name","teachers__name", "teachers__id"}, deferred)
+
+        data = serializer.data
+        expected_fields = {"id": None, "teachers": ["age"]}
+        # Assert top‐level keys exactly match
+        self.assertEqual(set(data.keys()), set(expected_fields.keys()))
+
+        # Assert nested fields.
+        self._assert_nested_fields(data, expected_fields)
+
+    def test_fields_all_gone_nested(self):
+        """If no fields are selected, all fields are omitted, including those
+        from the nested serializer.
+        """
+        rf = RequestFactory()
+        request = rf.get("/api/v1/schools/1/?fields")
+        school = self._prepare_school_instance()
+        serializer = SchoolSerializer(school, context={"request": request})
+
+        data = serializer.data
+        expected_fields = {}
+        # Assert top‐level keys exactly match
+        self.assertEqual(set(data.keys()), set(expected_fields.keys()))
+
+        # Assert nested fields.
+        self._assert_nested_fields(data, expected_fields)
+
+    def test_nested_omit_and_fields_used(self):
+        """Omit and fields can be used together at the nested field level."""
+        rf = RequestFactory()
+        request = rf.get(
+            "/api/v1/schools/1/?fields=id,name,teachers__name,teachers__age&omit=name,teachers__name"
+        )
+        school = self._prepare_school_instance()
+        serializer = SchoolSerializer(school, context={"request": request})
+
+        data = serializer.data
+        expected_fields = {"id": None, "teachers": ["age"]}
+        # Assert top‐level keys exactly match
+        self.assertEqual(set(data.keys()), set(expected_fields.keys()))
+
+        # Assert nested fields.
+        self._assert_nested_fields(data, expected_fields)
+
+    def test_omit_nothing_nested(self):
+        """
+        Blank omit doesn't affect nested fields.
+        """
+        rf = RequestFactory()
+        request = rf.get("/api/v1/schools/1/?omit")
+        school = self._prepare_school_instance()
+        serializer = SchoolSerializer(school, context={"request": request})
+
+        data = serializer.data
+        expected_fields = {
+            "id": None,
+            "name": None,
+            "teachers": ["id", "age", "name", "request_info"],
+        }
+        # Assert top‐level keys exactly match
+        self.assertEqual(set(data.keys()), set(expected_fields.keys()))
+
+        # Assert nested fields.
+        self._assert_nested_fields(data, expected_fields)
+
+    def test_single_nested_instance_omit_field(self):
+        """Omit also works for filtering fields on single nested instances"""
+        child = Child(secret="secret_key", public="public_key")
+        parent = Parent(id=1, child=child)
+        rf = RequestFactory()
+        request = rf.get("/api/v1/parent/1/?omit=id,child__secret")
+        serializer = ParentSerializer(parent, context={"request": request})
+        data = serializer.data
+
+        self.assertNotIn("id", data)
+        self.assertNotIn("secret", data["child"])
+        self.assertEqual(data["child"]["public"], "public_key")
+
+    def test_single_nested_instance_allow_field(self):
+        """Fields selection also works for filtering fields on single nested instances"""
+        child = Child(secret="secret_key", public="public_key")
+        parent = Parent(id=1, child=child)
+        rf = RequestFactory()
+        request = rf.get("/api/v1/parent/1/?fields=id,child__secret")
+        serializer = ParentSerializer(parent, context={"request": request})
+        data = serializer.data
+
+        self.assertEqual(data["id"], 1)
+        self.assertIn("secret", data["child"])
+        self.assertEqual(data["child"]["secret"], "secret_key")
+        self.assertNotIn("public", data["child"])


### PR DESCRIPTION
#42 replacement for this PR

@albertisfu here is an alternative approach where we do allow each serializer the ability to filter itself instead of orchestrating the filtering from the parent.

Does this approach work for your use-case? You can see that this cuts down on the logic spread throughout the fields method, and contains the hard work of finding the fields to filter / omit in some helper functions - I'm sure these could be simplified further - they are just gpt code. (for example I don't like `while` statements as a rule)

